### PR TITLE
Fix language for browser for calculations

### DIFF
--- a/InstAnalytics.py
+++ b/InstAnalytics.py
@@ -22,7 +22,9 @@ users = ['yotta_life']
 def InstAnalytics():
 
 	# Launch browser
-	browser = webdriver.PhantomJS(desired_capabilities=dcap)
+	options = webdriver.ChromeOptions()
+	options.add_experimental_option('prefs', {'intl.accept_languages': 'en,en_US'})
+	browser = webdriver.Chrome(options=options)
 
 	for user in users:
 


### PR DESCRIPTION
Fix the language to English in the browser, so that the script can run in an unified way. This is important for example for the number calculations (eg 750k followers = 750.000)