### PR TITLE
Fix loop for scrolling through page

### DIFF
--- a/InstAnalytics.py
+++ b/InstAnalytics.py
@@ -65,7 +65,7 @@ def InstAnalytics():
 
 		if posts > 24:
 			# Load more by scrolling to the bottom of the page
-			for i in range (0, (posts-24)//12):
+			for i in range (0, (posts-24)//12 + 1):
 				browser.execute_script('window.scrollTo(0, document.body.scrollHeight)')
 				time.sleep(0.1)
 				browser.execute_script('window.scrollTo(0, 0)')


### PR DESCRIPTION
Fix scrolling through the user page, when more than 24 posts available (should at least scroll once in theory at 25+ posts, although it seems this is now an irrelevant feature in current Instagram)